### PR TITLE
Feature: upgrade to Laravel 11 and drop PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3]
-        laravel: [10]
+        php: [8.2, 8.3]
+        laravel: [11]
 
     steps:
     - name: Checkout Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
-## Unreleased
+## Unreleased (Laravel 11)
+
+### Changed
+
+- **BREAKING** Package now requires Laravel 11.
+- Minimum PHP version is now `8.2`.
 
 ## [2.0.1] - 2023-10-29
 

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "2.x-dev",
-            "dev-laravel11": "3.x-dev"
+            "dev-develop": "3.x-dev"
         },
         "laravel": {
             "providers": [
@@ -55,7 +54,7 @@
             ]
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,15 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
-        "illuminate/contracts": "^10.0",
-        "illuminate/pipeline": "^10.0",
-        "illuminate/support": "^10.0",
-        "laravel-json-api/core": "^3.0"
+        "illuminate/contracts": "^11.0",
+        "illuminate/pipeline": "^11.0",
+        "illuminate/support": "^11.0",
+        "laravel-json-api/core": "^4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^9.0",
         "phpunit/phpunit": "^10.5"
     },
     "autoload": {
@@ -46,7 +46,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "2.x-dev"
+            "dev-develop": "2.x-dev",
+            "dev-laravel11": "3.x-dev"
         },
         "laravel": {
             "providers": [
@@ -54,7 +55,7 @@
             ]
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Changes to upgrade to Laravel 11, dropping PHP 8.1 at the same time.